### PR TITLE
send email on talk suggestion

### DIFF
--- a/test/other_web/emails_test.exs
+++ b/test/other_web/emails_test.exs
@@ -28,4 +28,12 @@ defmodule ElixirLangMoscow.EmailsTest do
 
     assert Enum.any?(mailbox, fn(v) -> v.headers["Message-ID"] == id end)
   end
+
+  test "email is sent on talk suggestion", %{suggested_talk: suggested_talk} do
+    email = Emails.create(suggested_talk, :suggested_talk)
+    {:ok, %{id: id}} = Emails.send_email(email)
+    mailbox = Swoosh.Adapters.Local.Storage.Memory.all()
+
+    assert Enum.any?(mailbox, fn(v) -> v.headers["Message-ID"] == id end)
+  end
 end

--- a/web/controllers/suggested_talk_controller.ex
+++ b/web/controllers/suggested_talk_controller.ex
@@ -2,6 +2,7 @@ defmodule ElixirLangMoscow.SuggestedTalkController do
   use ElixirLangMoscow.Web, :controller
 
   alias ElixirLangMoscow.SuggestedTalk
+  alias ElixirLangMoscow.Emails
 
   plug :scrub_params, "suggested_talk" when action in [:create]
 
@@ -26,7 +27,10 @@ defmodule ElixirLangMoscow.SuggestedTalkController do
     changeset = SuggestedTalk.changeset(%SuggestedTalk{}, suggested_talk_params)
 
     case Repo.insert(changeset) do
-      {:ok, _suggested_talk} ->
+      {:ok, suggested_talk} ->
+        Emails.create_and_send(
+          suggested_talk, :suggested_talk, :async)
+
         conn
         |> put_flash(:info, "Ok")
         |> redirect(to: suggested_talk_path(conn, :new))

--- a/web/emails/emails.ex
+++ b/web/emails/emails.ex
@@ -8,7 +8,7 @@ defmodule ElixirLangMoscow.Emails do
 
   @default_from {"Elixir Moscow Team", "no-reply@elixir-lang.moscow"}
 
-  def create(%SuggestedTalk{} = talk, :sugested_talk) do
+  def create(%SuggestedTalk{} = talk, :suggested_talk) do
     new
     |> to("talk@elixir-lang.moscow")
     |> from(@default_from)


### PR DESCRIPTION
При предложении нового доклада, не отправляется письмо с оповещением

Хотя в Emails уже для этого все есть 
```
 def create(%SuggestedTalk{} = talk, :suggested_talk) do
...
```

Добавил в контроллер отправку письма